### PR TITLE
Implementation of refresh token as a httpOnly cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,36 @@ Guide for writing change logs.
 
 `Fixed`  for any bug fixes.
 
+## 2023-09-08
+
+### Added
+
+
+### Changed
+- Changed the property `spring.jpa.show-sql` to `false` in the `application.properties` file.
+
+
+- Changed the property `refreshToken` in the `AuthenticationResponse` to be ignored by the JSON parser.
+
+
+- In the `AuthenticationController` changed the `refreshToken` to be set as a cookie in the authentication endpoint only.
+
+
+- In the `AuthenticationController` added the endpoint `api/v1/auth/logout` which deletes the refresh token cookie.
+
+
+- in the `AuthenticationService` changed the `authenticate` function to set the `refreshToken` as a cookie in the response.
+
+
+- in the `SecurityConfiguration` added a `CorsConfigurationSource` bean to allow CORS requests from the frontend.
+
+### Deprecated
+
+
+### Removed
+- Removed the `WebMvcConfigurer` bean in the `BookedApiApplication` class.
+
+### Fixed
 
 ## 2023-08-29
 

--- a/src/main/java/com/telmopanacas/bookedapi/BookedApiApplication.java
+++ b/src/main/java/com/telmopanacas/bookedapi/BookedApiApplication.java
@@ -13,15 +13,4 @@ public class BookedApiApplication {
         SpringApplication.run(BookedApiApplication.class, args);
     }
 
-    @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                //WebMvcConfigurer.super.addCorsMappings(registry);
-                registry.addMapping("/**");
-            }
-        };
-    }
-
 }

--- a/src/main/java/com/telmopanacas/bookedapi/Security/Auth/AuthenticationController.java
+++ b/src/main/java/com/telmopanacas/bookedapi/Security/Auth/AuthenticationController.java
@@ -1,12 +1,10 @@
 package com.telmopanacas.bookedapi.Security.Auth;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
@@ -29,9 +27,17 @@ public class AuthenticationController {
 
     @PostMapping("/authenticate")
     public ResponseEntity<AuthenticationResponse> authenticate(
-            @RequestBody AuthenticationRequest request
+            @RequestBody AuthenticationRequest request,
+            HttpServletResponse response
     ) {
-        return ResponseEntity.ok(authenticationService.authenticate(request));
+        return ResponseEntity.ok(authenticationService.authenticate(request, response));
+    }
+
+    @PostMapping("/logout")
+    public void login(
+            HttpServletResponse response
+    ) {
+        authenticationService.logout(response);
     }
 
     @PostMapping("/refresh-token")

--- a/src/main/java/com/telmopanacas/bookedapi/Security/Auth/AuthenticationResponse.java
+++ b/src/main/java/com/telmopanacas/bookedapi/Security/Auth/AuthenticationResponse.java
@@ -1,11 +1,13 @@
 package com.telmopanacas.bookedapi.Security.Auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AuthenticationResponse {
     @JsonProperty("access_token")
     private String accessToken;
     @JsonProperty("refresh_token")
+    @JsonIgnore
     private String refreshToken;
 
     public AuthenticationResponse(String accessToken, String refreshToken) {

--- a/src/main/java/com/telmopanacas/bookedapi/Security/Configuration/SecurityConfiguration.java
+++ b/src/main/java/com/telmopanacas/bookedapi/Security/Configuration/SecurityConfiguration.java
@@ -3,11 +3,19 @@ package com.telmopanacas.bookedapi.Security.Configuration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -24,13 +32,15 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
+                .cors(config -> config.configurationSource(corsConfigurationSource()))
+
                 .csrf()
                 .disable()
                 .authorizeHttpRequests()
                 .requestMatchers(
                         "/api/v1/auth/**",
                         "/api/v1/alive",
-                        "/api/v1/avaliacao/all"
+                        "api/v1/avaliacao/all"
                 )
                 .permitAll()
                 .anyRequest()
@@ -43,4 +53,20 @@ public class SecurityConfiguration {
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return  httpSecurity.build();
     }
+
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "PUT", "POST", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "content-type", "Cookie"));
+        configuration.setExposedHeaders(List.of("Authorization", "content-type", "Cookie"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,6 @@ server.servlet.encoding.force=true
 
 #hibernate properties
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 server.error.include-message=always


### PR DESCRIPTION
Changed the refresh token from being sent in the body of the response to be sent as a httpOnly cookie in the response.
Also added a CorsConfigurationSource to allow the reactjs front end to reach the protected endpoints.